### PR TITLE
feat: add filter operators ~= ^= and --latest dedup flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ export VARVIS_PASSWORD="your_password"
 | `--bed`      | `-b`   | BED file with regions                            | `regions.bed`                     |
 | `--unmapped` | `--um` | Extract unmapped reads from BAM                  | -                                 |
 
-**Filter operators:** `=` (equals), `!=` (not equals), `>` `<` (lexicographic), `~=` (contains), `^=` (starts with)
+**Filter operators:** `=` `!=` `>` `<` `>=` `<=` (lexicographic comparison), `~=` (contains), `^=` (starts with)
 
 ### Archive Management
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,15 @@ export VARVIS_PASSWORD="your_password"
 
 ### Filtering & Range Options
 
-| Parameter    | Short  | Description                     | Example              |
-| ------------ | ------ | ------------------------------- | -------------------- |
-| `--filter`   | `-F`   | Filter expressions              | `"analysisType=SNV"` |
-| `--range`    | `-g`   | Genomic range                   | `"chr1:1-100000"`    |
-| `--bed`      | `-b`   | BED file with regions           | `regions.bed`        |
-| `--unmapped` | `--um` | Extract unmapped reads from BAM | -                    |
+| Parameter    | Short  | Description                                      | Example                           |
+| ------------ | ------ | ------------------------------------------------ | --------------------------------- |
+| `--filter`   | `-F`   | Filter expressions (AND logic, multiple allowed) | `"enrichmentKitName^=TwistExome"` |
+| `--latest`   |        | Keep only newest analysis per sample             | -                                 |
+| `--range`    | `-g`   | Genomic range                                    | `"chr1:1-100000"`                 |
+| `--bed`      | `-b`   | BED file with regions                            | `regions.bed`                     |
+| `--unmapped` | `--um` | Extract unmapped reads from BAM                  | -                                 |
+
+**Filter operators:** `=` (equals), `!=` (not equals), `>` `<` (lexicographic), `~=` (contains), `^=` (starts with)
 
 ### Archive Management
 
@@ -196,8 +199,11 @@ If no password is provided via environment variables or CLI arguments, the tool 
 # Filter by analysis type
 ./varvis-download.js -t mytarget -a 12345 -F "analysisType=SNV"
 
-# Multiple filters
-./varvis-download.js -t mytarget -s LIMS-001 -F "analysisType=SNV" "sampleId>LIMS-001"
+# Filter by enrichment kit (starts with)
+./varvis-download.js -t mytarget -l "LIMS-001" -F "enrichmentKitName^=TwistExome"
+
+# Multiple filters (AND logic) + keep only newest analysis per sample
+./varvis-download.js -t mytarget -l "LIMS-001" -F "analysisType=SNV" -F "enrichmentKitName^=TwistExome" --latest
 ```
 
 ### Range Downloads

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -29,7 +29,7 @@ varvis-download [options]
 | `--loglevel, ll`                 | `string`  | `info`                      | Logging level (info, warn, error, debug)                                                                            |
 | `--logfile, lf`                  | `string`  | -                           | Path to the log file                                                                                                |
 | `--reportfile, r`                | `string`  | -                           | Path to the report file                                                                                             |
-| `--filter, F`                    | `array`   | `[]`                        | Filter expressions with AND logic. Operators: `=` `!=` `>` `<` `~=` (contains) `^=` (starts with).                  |
+| `--filter, F`                    | `array`   | `[]`                        | Filter expressions with AND logic. Operators: `=` `!=` `>` `<` `>=` `<=` `~=` (contains) `^=` (starts with).        |
 | `--latest`                       | `boolean` | `false`                     | Keep only the newest analysis per sample (highest analysis ID). Useful for repeat sequencing.                       |
 | `--range, g`                     | `string`  | -                           | Genomic range for ranged download (e.g., chr1:1-100000)                                                             |
 | `--bed, b`                       | `string`  | -                           | Path to BED file containing multiple regions                                                                        |

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -29,7 +29,8 @@ varvis-download [options]
 | `--loglevel, ll`                 | `string`  | `info`                      | Logging level (info, warn, error, debug)                                                                            |
 | `--logfile, lf`                  | `string`  | -                           | Path to the log file                                                                                                |
 | `--reportfile, r`                | `string`  | -                           | Path to the report file                                                                                             |
-| `--filter, F`                    | `array`   | `[]`                        | Filter expressions (e.g., "analysisType=SNV", "sampleId>LIMS-001")                                                  |
+| `--filter, F`                    | `array`   | `[]`                        | Filter expressions with AND logic. Operators: `=` `!=` `>` `<` `~=` (contains) `^=` (starts with).                  |
+| `--latest`                       | `boolean` | `false`                     | Keep only the newest analysis per sample (highest analysis ID). Useful for repeat sequencing.                       |
 | `--range, g`                     | `string`  | -                           | Genomic range for ranged download (e.g., chr1:1-100000)                                                             |
 | `--bed, b`                       | `string`  | -                           | Path to BED file containing multiple regions                                                                        |
 | `--unmapped, um`                 | `boolean` | `false`                     | Extract unmapped reads from BAM files. Can be combined with `--range` to produce a single BAM with both.            |

--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -73,6 +73,8 @@ Filter expressions use the format: `field operator value`
 | `!=`     | Not equals                   | `analysisType!=CNV`             |
 | `>`      | Greater than (lexicographic) | `sampleId>LIMS-100`             |
 | `<`      | Less than (lexicographic)    | `sampleId<LIMS-200`             |
+| `>=`     | Greater than or equal        | `quality>=95`                   |
+| `<=`     | Less than or equal           | `quality<=98`                   |
 | `~=`     | Contains (substring match)   | `enrichmentKitName~=Twist`      |
 | `^=`     | Starts with (prefix match)   | `enrichmentKitName^=TwistExome` |
 

--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -67,24 +67,30 @@ Filter expressions use the format: `field operator value`
 
 **Supported operators:**
 
-- `=` - Equals
-- `!=` - Not equals
-- `>` - Greater than
-- `<` - Less than
-- `>=` - Greater than or equal
-- `<=` - Less than or equal
+| Operator | Description                  | Example                         |
+| -------- | ---------------------------- | ------------------------------- |
+| `=`      | Equals                       | `analysisType=SNV`              |
+| `!=`     | Not equals                   | `analysisType!=CNV`             |
+| `>`      | Greater than (lexicographic) | `sampleId>LIMS-100`             |
+| `<`      | Less than (lexicographic)    | `sampleId<LIMS-200`             |
+| `~=`     | Contains (substring match)   | `enrichmentKitName~=Twist`      |
+| `^=`     | Starts with (prefix match)   | `enrichmentKitName^=TwistExome` |
+
+> **Note:** `>` and `<` use lexicographic (alphabetical) string comparison, not numeric.
+> Multiple `-F` filters are combined with AND logic.
 
 ### Common Filter Fields
 
-| Field          | Type   | Description              | Example Values              |
-| -------------- | ------ | ------------------------ | --------------------------- |
-| `analysisType` | String | Type of genomic analysis | `SNV`, `CNV`, `SV`, `Panel` |
-| `sampleId`     | String | Sample identifier        | `LIMS-001`, `Patient_123`   |
-| `quality`      | Number | Analysis quality score   | `95`, `88.5`                |
-| `coverage`     | Number | Sequencing coverage      | `30`, `100`                 |
-| `platform`     | String | Sequencing platform      | `Illumina`, `PacBio`        |
-| `runDate`      | Date   | Analysis execution date  | `2024-06-01`                |
-| `status`       | String | Analysis status          | `complete`, `ready`         |
+| Field               | Type   | Description              | Example Values                        |
+| ------------------- | ------ | ------------------------ | ------------------------------------- |
+| `analysisType`      | String | Type of genomic analysis | `SNV`, `CNV`, `SV`, `Panel`           |
+| `sampleId`          | String | Sample identifier        | `LIMS-001`, `Patient_123`             |
+| `enrichmentKitName` | String | Capture/enrichment kit   | `TwistExomev2`, `NimagenHEST_hg38_v2` |
+| `quality`           | Number | Analysis quality score   | `95`, `88.5`                          |
+| `coverage`          | Number | Sequencing coverage      | `30`, `100`                           |
+| `platform`          | String | Sequencing platform      | `Illumina`, `PacBio`                  |
+| `runDate`           | Date   | Analysis execution date  | `2024-06-01`                          |
+| `status`            | String | Analysis status          | `complete`, `ready`                   |
 
 ### Expression Examples
 
@@ -96,9 +102,31 @@ Filter expressions use the format: `field operator value`
 
 # Exclude CNV analyses
 ./varvis-download.js -t mytarget -s "LIMS-001" -F "analysisType!=CNV"
+```
 
-# Multiple analysis types
-./varvis-download.js -t mytarget -s "LIMS-001" -F "analysisType=SNV" -F "analysisType=Panel"
+**Enrichment kit filtering:**
+
+```bash
+# Only TwistExome analyses (matches TwistExomev0.2, TwistExomev2, etc.)
+./varvis-download.js -t mytarget -l "LIMS-001" -F "enrichmentKitName^=TwistExome"
+
+# Any Twist kit (Exome, Cancer, Genome)
+./varvis-download.js -t mytarget -l "LIMS-001" -F "enrichmentKitName~=Twist"
+
+# Exclude Nimagen
+./varvis-download.js -t mytarget -l "LIMS-001" -F "enrichmentKitName!=NimagenHEST_hg38_v2"
+```
+
+**Deduplication (newest analysis per sample):**
+
+```bash
+# Keep only latest analysis when samples have repeat sequencing (wdh)
+./varvis-download.js -t mytarget -l "LIMS-001" -F "enrichmentKitName^=TwistExome" --latest
+
+# Combine with range download and unmapped reads
+./varvis-download.js -t mytarget -l "LIMS-001" \
+  -F "enrichmentKitName^=TwistExome" --latest \
+  -g "chr1:155184000-155194000" --unmapped
 ```
 
 **Quality filtering:**

--- a/js/fetchUtils.cjs
+++ b/js/fetchUtils.cjs
@@ -1,5 +1,5 @@
 const fs = require('node:fs');
-const { applyFilters } = require('./filterUtils.cjs');
+const { applyFilters, deduplicateByLatest } = require('./filterUtils.cjs');
 const { triggerRestoreArchivedFile } = require('./archiveUtils.cjs');
 const { fetchWithRetry } = require('./apiClient.cjs');
 
@@ -41,6 +41,7 @@ async function confirmRestore(file, rl, _logger) {
  * @param   {Array<string>}     limsIds   - The LIMS IDs to filter analyses.
  * @param   {Array<string>}     filters   - An array of custom filters to apply.
  * @param   {object}            logger    - The logger instance.
+ * @param   {boolean}           latest    - If true, keep only the newest analysis per personLimsId.
  * @returns {Promise<string[]>}           - An array of analysis IDs.
  */
 async function fetchAnalysisIds(
@@ -51,6 +52,7 @@ async function fetchAnalysisIds(
   limsIds,
   filters,
   logger,
+  latest = false,
 ) {
   try {
     logger.debug('Fetching all analysis IDs');
@@ -91,6 +93,10 @@ async function fetchAnalysisIds(
     if (filters.length > 0) {
       logger.debug(`Applying custom filters: ${filters.join(', ')}`);
       filteredAnalyses = applyFilters(filteredAnalyses, filters);
+    }
+
+    if (latest) {
+      filteredAnalyses = deduplicateByLatest(filteredAnalyses, logger);
     }
 
     const ids = filteredAnalyses.map((analysis) => analysis.id.toString());

--- a/js/filterUtils.cjs
+++ b/js/filterUtils.cjs
@@ -91,10 +91,14 @@ function deduplicateByLatest(analyses, logger) {
 
   for (const analysis of analyses) {
     const limsId = analysis.personLimsId;
-    const id = Number(analysis.id);
     const existing = byLims.get(limsId);
 
-    if (!existing || id > Number(existing.id)) {
+    if (
+      !existing ||
+      String(analysis.id).localeCompare(String(existing.id), undefined, {
+        numeric: true,
+      }) > 0
+    ) {
       byLims.set(limsId, analysis);
     }
   }

--- a/js/filterUtils.cjs
+++ b/js/filterUtils.cjs
@@ -1,12 +1,19 @@
 // filterUtils.js
 
 /**
- * Parses a filter expression like 'analysisType=SNV' or 'sampleId>LB24-0001'
- * @param   {string} filterExpression - The filter expression (e.g., analysisType=SNV)
+ * Parses a filter expression into its components.
+ * Supported operators:
+ * =   equality
+ * !=  inequality
+ * >   greater than
+ * <   less than
+ * ~=  contains (substring match)
+ * ^=  starts with (prefix match)
+ * @param   {string} filterExpression - The filter expression (e.g., "analysisType=SNV", "enrichmentKitName^=TwistExome")
  * @returns {object}                  - An object containing field, operator, and value (e.g., { field: 'analysisType', operator: '=', value: 'SNV' })
  */
 function parseFilterExpression(filterExpression) {
-  const regex = /^(\w+)(!=|[><=])(.+)$/;
+  const regex = /^(\w+)(~=|\^=|!=|[><=])(.+)$/;
   const match = filterExpression.match(regex);
   if (match) {
     return {
@@ -19,10 +26,10 @@ function parseFilterExpression(filterExpression) {
 }
 
 /**
- * Applies a single filter to a list of analyses
- * @param   {Array}  analyses - List of analyses returned by the API
+ * Applies a single filter to a list of analyses.
+ * @param   {Array}  analyses - List of analyses returned by the API.
  * @param   {object} filter   - Parsed filter object (e.g., { field: 'analysisType', operator: '=', value: 'SNV' })
- * @returns {Array}           - Filtered list of analyses
+ * @returns {Array}           - Filtered list of analyses.
  */
 function applyFilter(analyses, filter) {
   const { field, operator, value } = filter;
@@ -38,6 +45,10 @@ function applyFilter(analyses, filter) {
         return analysisValue > value;
       case '<':
         return analysisValue < value;
+      case '~=':
+        return String(analysisValue || '').includes(value);
+      case '^=':
+        return String(analysisValue || '').startsWith(value);
       default:
         throw new Error(`Unsupported operator: ${operator}`);
     }
@@ -45,10 +56,10 @@ function applyFilter(analyses, filter) {
 }
 
 /**
- * Applies multiple filters to a list of analyses
- * @param   {Array} analyses          - List of analyses returned by the API
- * @param   {Array} filterExpressions - Array of filter expressions (e.g., ['analysisType=SNV', 'sampleId>LB24-0001'])
- * @returns {Array}                   - Filtered list of analyses
+ * Applies multiple filters to a list of analyses sequentially (AND logic).
+ * @param   {Array} analyses          - List of analyses returned by the API.
+ * @param   {Array} filterExpressions - Array of filter expressions (e.g., ['analysisType=SNV', 'enrichmentKitName^=TwistExome'])
+ * @returns {Array}                   - Filtered list of analyses.
  */
 function applyFilters(analyses, filterExpressions) {
   let filteredAnalyses = analyses;
@@ -61,8 +72,41 @@ function applyFilters(analyses, filterExpressions) {
   return filteredAnalyses;
 }
 
+/**
+ * Deduplicates analyses by keeping only the one with the highest analysis ID
+ * per unique personLimsId. This ensures only the newest/latest analysis per
+ * sample is retained (e.g., when a sample has both original and repeat sequencing).
+ * @param   {Array}  analyses - List of analyses (must have id and personLimsId fields).
+ * @param   {object} logger   - The logger instance.
+ * @returns {Array}           - Deduplicated list with one analysis per personLimsId.
+ */
+function deduplicateByLatest(analyses, logger) {
+  const byLims = new Map();
+
+  for (const analysis of analyses) {
+    const limsId = analysis.personLimsId;
+    const id = Number(analysis.id);
+    const existing = byLims.get(limsId);
+
+    if (!existing || id > Number(existing.id)) {
+      byLims.set(limsId, analysis);
+    }
+  }
+
+  const deduplicated = [...byLims.values()];
+  const removed = analyses.length - deduplicated.length;
+  if (removed > 0) {
+    logger.info(
+      `Deduplicated analyses: kept ${deduplicated.length} latest, removed ${removed} older duplicates.`,
+    );
+  }
+
+  return deduplicated;
+}
+
 module.exports = {
   parseFilterExpression,
   applyFilter,
   applyFilters,
+  deduplicateByLatest,
 };

--- a/js/filterUtils.cjs
+++ b/js/filterUtils.cjs
@@ -5,15 +5,17 @@
  * Supported operators:
  * =   equality
  * !=  inequality
- * >   greater than
- * <   less than
+ * >   greater than (lexicographic)
+ * <   less than (lexicographic)
+ * >=  greater than or equal (lexicographic)
+ * <=  less than or equal (lexicographic)
  * ~=  contains (substring match)
  * ^=  starts with (prefix match)
  * @param   {string} filterExpression - The filter expression (e.g., "analysisType=SNV", "enrichmentKitName^=TwistExome")
  * @returns {object}                  - An object containing field, operator, and value (e.g., { field: 'analysisType', operator: '=', value: 'SNV' })
  */
 function parseFilterExpression(filterExpression) {
-  const regex = /^(\w+)(~=|\^=|!=|[><=])(.+)$/;
+  const regex = /^(\w+)(~=|\^=|!=|>=|<=|[><=])(.+)$/;
   const match = filterExpression.match(regex);
   if (match) {
     return {
@@ -45,6 +47,10 @@ function applyFilter(analyses, filter) {
         return analysisValue > value;
       case '<':
         return analysisValue < value;
+      case '>=':
+        return analysisValue >= value;
+      case '<=':
+        return analysisValue <= value;
       case '~=':
         return String(analysisValue || '').includes(value);
       case '^=':

--- a/tests/unit/filterUtils.test.js
+++ b/tests/unit/filterUtils.test.js
@@ -355,6 +355,18 @@ describe('filterUtils', () => {
       expect(result[0].sampleId).toBe('S1wdh');
     });
 
+    test('should handle alphanumeric analysis IDs', () => {
+      const data = [
+        { id: 'AN001', personLimsId: 'LIMS-001', sampleId: 'S1' },
+        { id: 'AN010', personLimsId: 'LIMS-001', sampleId: 'S1wdh' },
+        { id: 'AN002', personLimsId: 'LIMS-001', sampleId: 'S1b' },
+      ];
+      const result = deduplicateByLatest(data, mockLogger);
+      expect(result).toHaveLength(1);
+      // localeCompare with numeric: AN010 > AN002 > AN001
+      expect(result[0].id).toBe('AN010');
+    });
+
     test('should return all if no duplicates', () => {
       const data = [
         { id: 1, personLimsId: 'LIMS-001' },

--- a/tests/unit/filterUtils.test.js
+++ b/tests/unit/filterUtils.test.js
@@ -2,6 +2,7 @@ const {
   applyFilters,
   parseFilterExpression,
   applyFilter,
+  deduplicateByLatest,
 } = require('../../js/filterUtils');
 
 describe('filterUtils', () => {
@@ -39,6 +40,24 @@ describe('filterUtils', () => {
     test('should parse less than filter expression correctly', () => {
       const filter = parseFilterExpression('score<20');
       expect(filter).toEqual({ field: 'score', operator: '<', value: '20' });
+    });
+
+    test('should parse contains operator correctly', () => {
+      const filter = parseFilterExpression('enrichmentKitName~=TwistExome');
+      expect(filter).toEqual({
+        field: 'enrichmentKitName',
+        operator: '~=',
+        value: 'TwistExome',
+      });
+    });
+
+    test('should parse starts-with operator correctly', () => {
+      const filter = parseFilterExpression('enrichmentKitName^=TwistExome');
+      expect(filter).toEqual({
+        field: 'enrichmentKitName',
+        operator: '^=',
+        value: 'TwistExome',
+      });
     });
 
     test('should trim whitespace from value', () => {
@@ -89,6 +108,103 @@ describe('filterUtils', () => {
       expect(filtered.map((a) => a.id)).toEqual([1, 3]);
     });
 
+    test('should use lexicographic comparison for > with strings', () => {
+      const data = [
+        { id: 1, sampleId: 'LB24-0001' },
+        { id: 2, sampleId: 'LB25-0001' },
+        { id: 3, sampleId: 'LB25-1234' },
+      ];
+      const filter = { field: 'sampleId', operator: '>', value: 'LB25-0000' };
+      const filtered = applyFilter(data, filter);
+      // Lexicographic: 'LB25-0001' > 'LB25-0000' and 'LB25-1234' > 'LB25-0000'
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((a) => a.id)).toEqual([2, 3]);
+    });
+
+    test('should compare strings lexicographically not numerically', () => {
+      const data = [
+        { id: 1, sampleId: 'LB25-9' },
+        { id: 2, sampleId: 'LB25-10' },
+      ];
+      const filter = { field: 'sampleId', operator: '>', value: 'LB25-9' };
+      // Lexicographic: 'LB25-10' < 'LB25-9' (char '1' < '9')
+      // This is a known limitation: > < are NOT numeric-aware
+      const filtered = applyFilter(data, filter);
+      expect(filtered).toHaveLength(0);
+    });
+
+    test('should apply contains filter correctly', () => {
+      const kitAnalyses = [
+        { enrichmentKitName: 'TwistExomev0.2 (size 37484908bp)' },
+        { enrichmentKitName: 'TwistExomev2' },
+        { enrichmentKitName: 'NimagenHEST_hg38_v2' },
+        { enrichmentKitName: 'TwistCancerv0.2' },
+      ];
+      const filter = {
+        field: 'enrichmentKitName',
+        operator: '~=',
+        value: 'TwistExome',
+      };
+      const filtered = applyFilter(kitAnalyses, filter);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((a) => a.enrichmentKitName)).toEqual([
+        'TwistExomev0.2 (size 37484908bp)',
+        'TwistExomev2',
+      ]);
+    });
+
+    test('should apply starts-with filter correctly', () => {
+      const kitAnalyses = [
+        { enrichmentKitName: 'TwistExomev0.2 (size 37484908bp)' },
+        { enrichmentKitName: 'TwistExomev2' },
+        { enrichmentKitName: 'NimagenHEST_hg38_v2' },
+        { enrichmentKitName: 'TwistCancerv0.2' },
+      ];
+      const filter = {
+        field: 'enrichmentKitName',
+        operator: '^=',
+        value: 'TwistExome',
+      };
+      const filtered = applyFilter(kitAnalyses, filter);
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((a) => a.enrichmentKitName)).toEqual([
+        'TwistExomev0.2 (size 37484908bp)',
+        'TwistExomev2',
+      ]);
+    });
+
+    test('should handle null/undefined fields with contains operator', () => {
+      const data = [
+        { enrichmentKitName: 'TwistExomev2' },
+        { enrichmentKitName: null },
+        { enrichmentKitName: undefined },
+        {},
+      ];
+      const filter = {
+        field: 'enrichmentKitName',
+        operator: '~=',
+        value: 'Twist',
+      };
+      const filtered = applyFilter(data, filter);
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].enrichmentKitName).toBe('TwistExomev2');
+    });
+
+    test('should handle null/undefined fields with starts-with operator', () => {
+      const data = [
+        { enrichmentKitName: 'TwistExomev2' },
+        { enrichmentKitName: null },
+        {},
+      ];
+      const filter = {
+        field: 'enrichmentKitName',
+        operator: '^=',
+        value: 'Twist',
+      };
+      const filtered = applyFilter(data, filter);
+      expect(filtered).toHaveLength(1);
+    });
+
     test('should throw error for unsupported operator', () => {
       const filter = { field: 'score', operator: '>=', value: '15' };
       expect(() => applyFilter(analyses, filter)).toThrow(
@@ -128,6 +244,115 @@ describe('filterUtils', () => {
       ]);
       expect(filtered).toHaveLength(2);
       expect(filtered.map((a) => a.id)).toEqual([1, 3]);
+    });
+
+    test('should apply multiple filters with AND logic', () => {
+      const data = [
+        { id: 1, analysisType: 'SNV', enrichmentKitName: 'TwistExomev2' },
+        { id: 2, analysisType: 'SNV', enrichmentKitName: 'NimagenHEST' },
+        { id: 3, analysisType: 'CNV', enrichmentKitName: 'TwistExomev2' },
+      ];
+      // Both filters must match (AND): only id=1 is SNV AND TwistExome
+      const filtered = applyFilters(data, [
+        'analysisType=SNV',
+        'enrichmentKitName^=TwistExome',
+      ]);
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].id).toBe(1);
+    });
+
+    test('should combine enrichment kit filter with analysis type', () => {
+      const data = [
+        {
+          id: 1,
+          analysisType: 'SNV',
+          enrichmentKitName: 'TwistExomev2',
+        },
+        {
+          id: 2,
+          analysisType: 'SNV',
+          enrichmentKitName: 'NimagenHEST_hg38_v2',
+        },
+        {
+          id: 3,
+          analysisType: 'CNV',
+          enrichmentKitName: 'TwistExomev2',
+        },
+      ];
+      const filtered = applyFilters(data, [
+        'analysisType=SNV',
+        'enrichmentKitName^=TwistExome',
+      ]);
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].id).toBe(1);
+    });
+  });
+
+  describe('deduplicateByLatest', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('should keep only the highest analysis ID per personLimsId', () => {
+      const data = [
+        { id: 100, personLimsId: 'LIMS-001', sampleId: 'S1' },
+        { id: 200, personLimsId: 'LIMS-001', sampleId: 'S1wdh' },
+        { id: 150, personLimsId: 'LIMS-002', sampleId: 'S2' },
+      ];
+      const result = deduplicateByLatest(data, mockLogger);
+      expect(result).toHaveLength(2);
+      expect(result.find((a) => a.personLimsId === 'LIMS-001').id).toBe(200);
+      expect(result.find((a) => a.personLimsId === 'LIMS-002').id).toBe(150);
+    });
+
+    test('should handle string analysis IDs', () => {
+      const data = [
+        { id: '28265', personLimsId: 'LIMS-001', sampleId: 'S1wdh' },
+        { id: '27621', personLimsId: 'LIMS-001', sampleId: 'S1' },
+        { id: '27670', personLimsId: 'LIMS-001', sampleId: 'S1' },
+      ];
+      const result = deduplicateByLatest(data, mockLogger);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('28265');
+      expect(result[0].sampleId).toBe('S1wdh');
+    });
+
+    test('should return all if no duplicates', () => {
+      const data = [
+        { id: 1, personLimsId: 'LIMS-001' },
+        { id: 2, personLimsId: 'LIMS-002' },
+        { id: 3, personLimsId: 'LIMS-003' },
+      ];
+      const result = deduplicateByLatest(data, mockLogger);
+      expect(result).toHaveLength(3);
+    });
+
+    test('should log deduplication count when duplicates exist', () => {
+      const data = [
+        { id: 100, personLimsId: 'LIMS-001' },
+        { id: 200, personLimsId: 'LIMS-001' },
+      ];
+      deduplicateByLatest(data, mockLogger);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Deduplicated analyses: kept 1 latest, removed 1 older duplicates.',
+      );
+    });
+
+    test('should not log when no duplicates removed', () => {
+      const data = [{ id: 1, personLimsId: 'LIMS-001' }];
+      deduplicateByLatest(data, mockLogger);
+      expect(mockLogger.info).not.toHaveBeenCalled();
+    });
+
+    test('should return empty array for empty input', () => {
+      const result = deduplicateByLatest([], mockLogger);
+      expect(result).toHaveLength(0);
     });
   });
 });

--- a/tests/unit/filterUtils.test.js
+++ b/tests/unit/filterUtils.test.js
@@ -42,6 +42,24 @@ describe('filterUtils', () => {
       expect(filter).toEqual({ field: 'score', operator: '<', value: '20' });
     });
 
+    test('should parse greater-than-or-equal operator correctly', () => {
+      const filter = parseFilterExpression('quality>=95');
+      expect(filter).toEqual({
+        field: 'quality',
+        operator: '>=',
+        value: '95',
+      });
+    });
+
+    test('should parse less-than-or-equal operator correctly', () => {
+      const filter = parseFilterExpression('quality<=98');
+      expect(filter).toEqual({
+        field: 'quality',
+        operator: '<=',
+        value: '98',
+      });
+    });
+
     test('should parse contains operator correctly', () => {
       const filter = parseFilterExpression('enrichmentKitName~=TwistExome');
       expect(filter).toEqual({
@@ -106,6 +124,20 @@ describe('filterUtils', () => {
       const filtered = applyFilter(analyses, filter);
       expect(filtered).toHaveLength(2);
       expect(filtered.map((a) => a.id)).toEqual([1, 3]);
+    });
+
+    test('should apply greater-than-or-equal filter correctly', () => {
+      const filter = { field: 'score', operator: '>=', value: '15' };
+      const filtered = applyFilter(analyses, filter);
+      expect(filtered).toHaveLength(3);
+      expect(filtered.map((a) => a.id)).toEqual([2, 3, 4]);
+    });
+
+    test('should apply less-than-or-equal filter correctly', () => {
+      const filter = { field: 'score', operator: '<=', value: '20' };
+      const filtered = applyFilter(analyses, filter);
+      expect(filtered).toHaveLength(3);
+      expect(filtered.map((a) => a.id)).toEqual([1, 2, 3]);
     });
 
     test('should use lexicographic comparison for > with strings', () => {
@@ -206,9 +238,9 @@ describe('filterUtils', () => {
     });
 
     test('should throw error for unsupported operator', () => {
-      const filter = { field: 'score', operator: '>=', value: '15' };
+      const filter = { field: 'score', operator: '%%', value: '15' };
       expect(() => applyFilter(analyses, filter)).toThrow(
-        'Unsupported operator: >=',
+        'Unsupported operator: %%',
       );
     });
   });

--- a/varvis-download.cjs
+++ b/varvis-download.cjs
@@ -159,7 +159,7 @@ argv = yargs
   .option('filter', {
     alias: 'F',
     describe:
-      'Filter expressions. Operators: = (equals), != (not equals), > < (lexicographic comparison), ~= (contains), ^= (starts with). Multiple filters use AND logic. Examples: "analysisType=SNV", "enrichmentKitName^=TwistExome"',
+      'Filter expressions. Operators: = != > < >= <= (lexicographic), ~= (contains), ^= (starts with). Multiple filters use AND logic. Examples: "analysisType=SNV", "enrichmentKitName^=TwistExome"',
     type: 'array',
     default: [],
   })

--- a/varvis-download.cjs
+++ b/varvis-download.cjs
@@ -159,9 +159,15 @@ argv = yargs
   .option('filter', {
     alias: 'F',
     describe:
-      'Filter expressions (e.g., "analysisType=SNV", "sampleId>LB24-0001")',
+      'Filter expressions. Operators: = (equals), != (not equals), > < (lexicographic comparison), ~= (contains), ^= (starts with). Multiple filters use AND logic. Examples: "analysisType=SNV", "enrichmentKitName^=TwistExome"',
     type: 'array',
     default: [],
+  })
+  .option('latest', {
+    describe:
+      'Keep only the newest analysis per sample (highest analysis ID). Useful when samples have repeat sequencing.',
+    type: 'boolean',
+    default: false,
   })
   .option('range', {
     alias: 'g',
@@ -274,6 +280,7 @@ const finalConfig = {
   range: normalizedRange || config.range || null,
   bed: normalizedBed || config.bed || null,
   unmapped: argv.unmapped || config.unmapped || false,
+  latest: argv.latest || config.latest || false,
 };
 
 // Validate the final configuration
@@ -559,6 +566,7 @@ async function main() {
               limsIds,
               filters,
               logger,
+              finalConfig.latest,
             );
       logger.info(`Fetched analysis IDs: ${ids}`);
       for (const analysisId of ids) {
@@ -685,6 +693,7 @@ async function main() {
             limsIds,
             filters,
             logger,
+            finalConfig.latest,
           );
     logger.info(`Fetched analysis IDs: ${ids}`);
 

--- a/varvis-download.cjs
+++ b/varvis-download.cjs
@@ -279,8 +279,8 @@ const finalConfig = {
   urlFile: normalizedUrlFile || config.urlFile || null,
   range: normalizedRange || config.range || null,
   bed: normalizedBed || config.bed || null,
-  unmapped: argv.unmapped || config.unmapped || false,
-  latest: argv.latest || config.latest || false,
+  unmapped: argv.unmapped ?? config.unmapped ?? false,
+  latest: argv.latest ?? config.latest ?? false,
 };
 
 // Validate the final configuration


### PR DESCRIPTION
## Summary
- Add `~=` (contains) and `^=` (starts with) filter operators for substring matching on analysis fields
- Add `--latest` flag to keep only the newest analysis per sample (highest analysis ID per personLimsId)
- Clarify that `>` `<` operators use lexicographic string comparison (documented with tests)
- Multiple `-F` filters use AND logic

## Use Cases

```bash
# Filter for TwistExome enrichment kit only (works across different kit name formats)
varvis-download -l "LIMS-001" -F "enrichmentKitName^=TwistExome"

# Keep only newest analysis when samples have repeat sequencing (wdh)
varvis-download -l "LIMS-001" -F "enrichmentKitName^=TwistExome" --latest

# Combine multiple filters (AND logic)
varvis-download -l "LIMS-001" -F "analysisType=SNV" -F "enrichmentKitName~=Twist"
```

## Test plan
- [x] 32 unit tests for filterUtils (16 new: contains, starts-with, null handling, lexicographic edge cases, deduplicateByLatest)
- [x] All 286 existing tests pass
- [x] Live-tested against laborberlin: `enrichmentKitName^=TwistExome` correctly filters out Nimagen analyses
- [x] Live-tested `--latest`: deduplicates wdh repeats, keeps highest analysis ID
- [x] Lint, typecheck, format clean