### PR TITLE
fix(deps): force js-yaml >=3.15.0 to resolve DoS advisory (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6793,9 +6793,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11210,7 +11210,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -14598,9 +14598,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "overrides": {
     "esbuild": "^0.25.0",
+    "js-yaml": "^3.15.0",
     "markdown-it": "^14.2.0",
     "vite": "^6.4.3"
   },


### PR DESCRIPTION
## Summary

Resolves the single open Dependabot security alert (#67): **js-yaml quadratic-complexity DoS in merge-key handling via repeated aliases** (`GHSA-h67p-54hq-rp68`, moderate).

`js-yaml` is a **dev-only transitive** dependency:

```
jest -> @jest/core -> @jest/transform -> babel-plugin-istanbul
  -> @istanbuljs/load-nyc-config (requests js-yaml ^3.13.1) -> js-yaml@3.14.2
```

The advisory is patched in `3.15.0`. Since `@istanbuljs/load-nyc-config` is effectively unmaintained, this pins the transitive dependency via an npm `overrides` entry (`"js-yaml": "^3.15.0"`). `3.15.0` satisfies the existing `^3.13.1` range, so nothing downstream breaks.

## Verification

- `npm audit` → **0 vulnerabilities** (was 1 moderate)
- `npm ls js-yaml` → resolves to `js-yaml@3.15.0`
- `npm run check` → lint / prettier / type-check / **448 tests** / architecture budget all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)