### PR TITLE
fix: scanning-for-bugs batch — retry/backoff, VCF argv, backpressure, proxy auth, temp BED race (#121–#125)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-scanning-bugs-batch-121-125.md
+++ b/docs/superpowers/plans/2026-07-07-scanning-bugs-batch-121-125.md
@@ -1,0 +1,537 @@
+# scanning-for-bugs batch (#121–#125) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix five independent, verified defects (#121–#125) with focused TDD, no regressions, and a green `npm run check`.
+
+**Architecture:** Each task fixes one production module and updates the tests that pin the buggy behavior. Tasks are independent and can run in any order; each ends with a passing focused test run and a commit.
+
+**Tech Stack:** Node.js 24 (repo floor ≥22.22.2), CommonJS `.cjs`, Jest 30, undici 8.7, ESLint 10 (jsdoc/unicorn/security), `tsc --noEmit` strict `checkJs`.
+
+## Global Constraints
+
+- CommonJS only in `js/` and root `*.cjs`: `require()` + `module.exports`, never ESM.
+- Use `node:` protocol for builtins (`require('node:fs')`). Enforced by `unicorn/prefer-node-protocol`.
+- JSDoc required on every exported function/class/method in `js/**/*.cjs` and root `*.cjs`.
+- Keep every file < 600 lines (warns at 500). All target files stay well under budget.
+- No new external deps, no new CLI flags. Only `node:` builtins added.
+- Focused test run: `npm test -- --testPathPatterns=<name>`. Full gate: `npm run check`.
+- Jest 30 uses `--testPathPatterns` (plural), not `--testPathPattern`.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` + `Claude-Session: https://claude.ai/code/session_01XRCFoXRU6wYdMrS3wYGiDE`.
+
+---
+
+### Task 1: fetchWithRetry — fast-fail 4xx + true exponential backoff (#125)
+
+**Files:**
+- Modify: `js/apiClient.cjs` (class `ApiClient`, method `fetchWithRetry`, lines ~35–59; add `HttpResponseError` + `BASE_DELAY_MS`; add to `module.exports`)
+- Test: `tests/unit/apiClient.test.js`
+
+**Interfaces:**
+- Produces: `HttpResponseError extends Error { status: number; retryable: boolean }`, exported from `js/apiClient.cjs`.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing tests** — append inside the existing `describe('ApiClient', () => { describe('fetchWithRetry', ...` block in `tests/unit/apiClient.test.js`:
+
+```js
+test('fails fast on 404 without retrying', async () => {
+  undici.fetch.mockResolvedValue({ ok: false, status: 404 });
+
+  const client = new ApiClient(mockAgent, mockLogger);
+
+  await expect(
+    client.fetchWithRetry('https://api.example.com', {}, 3),
+  ).rejects.toThrow('Fetch failed with status: 404');
+
+  expect(undici.fetch).toHaveBeenCalledTimes(1);
+  expect(mockLogger.warn).not.toHaveBeenCalled();
+  expect(mockLogger.error).toHaveBeenCalledWith(
+    'Fetch failed after 1 attempt: Fetch failed with status: 404',
+  );
+});
+
+test('retries on 429 (rate limited) then succeeds', async () => {
+  jest.useFakeTimers();
+  const successResponse = { ok: true, status: 200 };
+  undici.fetch
+    .mockResolvedValueOnce({ ok: false, status: 429 })
+    .mockResolvedValueOnce(successResponse);
+
+  const client = new ApiClient(mockAgent, mockLogger);
+  const promise = client.fetchWithRetry('https://api.example.com', {}, 3);
+  await jest.advanceTimersByTimeAsync(1000);
+  const response = await promise;
+
+  expect(response).toBe(successResponse);
+  expect(undici.fetch).toHaveBeenCalledTimes(2);
+  expect(mockLogger.warn).toHaveBeenCalledWith(
+    'Fetch attempt 1 failed. Retrying...',
+  );
+  jest.useRealTimers();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --testPathPatterns=apiClient`
+Expected: FAIL — 404 test sees 3 fetch calls (currently retries), 429 message/flow differs.
+
+- [ ] **Step 3: Implement** — in `js/apiClient.cjs`, after the `DEFAULT_HEADERS` const add:
+
+```js
+/**
+ * Base delay (ms) for exponential backoff between fetch retries.
+ * @type {number}
+ */
+const BASE_DELAY_MS = 1000;
+
+/**
+ * Error for a non-2xx HTTP response, tagging the status code and whether the
+ * failure is transient (network/5xx/429) and therefore worth retrying.
+ */
+class HttpResponseError extends Error {
+  /**
+   * @param {number} status - HTTP status code of the failed response.
+   */
+  constructor(status) {
+    super(`Fetch failed with status: ${status}`);
+    this.name = 'HttpResponseError';
+    /** @type {number} */
+    this.status = status;
+    /** @type {boolean} */
+    this.retryable = status >= 500 || status === 429;
+  }
+}
+```
+
+Replace the body of `fetchWithRetry` (the `try/catch` inside the loop) with:
+
+```js
+      try {
+        const response = await fetch(url, {
+          ...options,
+          headers: { ...DEFAULT_HEADERS, ...options.headers },
+          dispatcher: this.agent,
+        });
+        if (!response.ok) throw new HttpResponseError(response.status);
+        return response;
+      } catch (error) {
+        const isRetryable =
+          !(error instanceof HttpResponseError) || error.retryable;
+        if (isRetryable && attempt < retries) {
+          this.logger.warn(`Fetch attempt ${attempt} failed. Retrying...`);
+          await new Promise((res) =>
+            setTimeout(res, 2 ** (attempt - 1) * BASE_DELAY_MS),
+          );
+        } else {
+          this.logger.error(
+            `Fetch failed after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${getErrorMessage(error)}`,
+          );
+          throw error;
+        }
+      }
+```
+
+Add `HttpResponseError` to `module.exports`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPatterns=apiClient`
+Expected: PASS (all existing + 2 new). Existing "exponential backoff" test still passes (1000/2000 identical for first two retries).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/apiClient.cjs tests/unit/apiClient.test.js
+git commit -m "fix(apiClient): fast-fail permanent 4xx and use true exponential backoff (#125)"
+```
+
+---
+
+### Task 2: rangedDownloadVCF — argv array, no shell (#124)
+
+**Files:**
+- Modify: `js/rangedUtils.cjs:140-146`
+- Test: `tests/unit/rangedUtils.test.js:284-290, 390-394`
+
+**Interfaces:**
+- Produces: no signature change. `spawn('tabix', ['-h', url, range], { cwd: indexDir })`.
+
+- [ ] **Step 1: Update the failing tests first** — in `tests/unit/rangedUtils.test.js`, replace both `spawn('sh', ['-c', ...])` assertions.
+
+At ~line 284:
+
+```js
+      expect(spawn).toHaveBeenCalledWith('tabix', ['-h', url, range], {
+        cwd: expect.any(String),
+      });
+      expect(spawn).toHaveBeenCalledWith('bgzip', ['-c']);
+```
+
+At ~line 390:
+
+```js
+      // Verify tabix runs directly (no shell) with -h flag and argv array
+      expect(spawn).toHaveBeenCalledWith(
+        'tabix',
+        ['-h', 'https://example.com/test.vcf.gz', 'chr1:1000-2000'],
+        { cwd: '/path/to' },
+      );
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --testPathPatterns=rangedUtils`
+Expected: FAIL — production still spawns `sh`.
+
+- [ ] **Step 3: Implement** — in `js/rangedUtils.cjs`, replace lines 140–146:
+
+```js
+    // Command 1: tabix to extract the region with header.
+    // Spawn tabix directly with an argv array (no shell) so URL/range are inert
+    // to shell metacharacters — matching the safe BAM path.
+    logger.info(`Executing in ${indexDir}: tabix -h ${url} ${range}`);
+    const tabixProcess = spawn('tabix', ['-h', url, range], {
+      cwd: indexDir, // Execute in the directory where the index file is located
+    });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPatterns=rangedUtils`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/rangedUtils.cjs tests/unit/rangedUtils.test.js
+git commit -m "fix(rangedUtils): run tabix via argv array instead of sh -c for ranged VCF (#124)"
+```
+
+---
+
+### Task 3: downloadFile — honor writable backpressure (#123)
+
+**Files:**
+- Modify: `js/fileUtils.cjs` (add `node:events` require; loop at ~lines 84–89)
+- Test: `tests/unit/fileUtils.test.js`
+
+**Interfaces:**
+- Produces: no signature change.
+
+- [ ] **Step 1: Write the failing test** — in `tests/unit/fileUtils.test.js`, add `const { Writable } = require('node:stream');` near the top requires, then add inside `describe('downloadFile', ...`:
+
+```js
+test('awaits drain when the writable applies backpressure', async () => {
+  const dir = await testDir.create(`download-backpressure-${Date.now()}`);
+  const outputPath = path.join(dir, 'file.bin');
+
+  const order = [];
+  // hwm=1 forces write() to return false so the fix must await 'drain'.
+  const slowWriter = new Writable({
+    highWaterMark: 1,
+    write(chunk, _enc, cb) {
+      order.push(`write:${chunk.toString()}`);
+      setImmediate(cb);
+    },
+  });
+  jest.spyOn(fs, 'createWriteStream').mockReturnValue(slowWriter);
+
+  const chunks = ['a', 'b', 'c'];
+  const mockBody = {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        order.push(`pull:${c}`);
+        yield Buffer.from(c);
+      }
+    },
+  };
+  fetchWithRetry.mockResolvedValue({
+    body: mockBody,
+    headers: { get: () => '3' },
+  });
+
+  await downloadFile(
+    'https://example.com/file.bin',
+    outputPath,
+    true,
+    mockAgent,
+    mockRl,
+    mockLogger,
+    mockMetrics,
+  );
+
+  // Backpressure honored => pulls and writes strictly interleave 1:1.
+  expect(order).toEqual([
+    'pull:a',
+    'write:a',
+    'pull:b',
+    'write:b',
+    'pull:c',
+    'write:c',
+  ]);
+  expect(mockMetrics.totalBytesDownloaded).toBe(3);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPatterns=fileUtils`
+Expected: FAIL — without the fix, order is `pull:a, pull:b, pull:c, write:a, ...` (all pulls before writes).
+
+- [ ] **Step 3: Implement** — in `js/fileUtils.cjs`, add near the top requires:
+
+```js
+const { once } = require('node:events');
+```
+
+Replace the streaming loop (lines ~84–88):
+
+```js
+    for await (const chunk of response.body) {
+      totalBytes += chunk.length;
+      // Honor writable backpressure: when the internal buffer is full,
+      // write() returns false — wait for 'drain' before pulling more so
+      // memory stays bounded on large downloads with a slow sink.
+      if (!writer.write(chunk)) {
+        await once(writer, 'drain');
+      }
+      progressBar.tick(chunk.length);
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPatterns=fileUtils`
+Expected: PASS (new backpressure test + all existing — small-buffer tests never hit the drain path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/fileUtils.cjs tests/unit/fileUtils.test.js
+git commit -m "fix(fileUtils): honor writable backpressure in downloadFile (#123)"
+```
+
+---
+
+### Task 4: createHttpAgent — base64 proxy auth via undici token (#122)
+
+**Files:**
+- Modify: `js/net/httpAgent.cjs:25-29`
+- Test: `tests/unit/net/httpAgent.enhanced.test.js:39-43`
+
+**Interfaces:**
+- Produces: no signature change. Sets `agentOptions.token = 'Basic <base64(user:pass)>'`.
+
+- [ ] **Step 1: Update the failing test** — in `tests/unit/net/httpAgent.enhanced.test.js`, replace the both-credentials assertion (~lines 39–42):
+
+```js
+    expect(ProxyAgent).toHaveBeenCalledWith({
+      uri: 'http://example.test:8080',
+      token: 'Basic dXNlcjpwYXNz', // base64('user:pass')
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --testPathPatterns=httpAgent`
+Expected: FAIL — production still sets `auth: 'user:pass'`.
+
+- [ ] **Step 3: Implement** — in `js/net/httpAgent.cjs`, replace the credential block:
+
+```js
+  /** @type {import('undici').ProxyAgent.Options} */
+  const agentOptions = { uri: proxy };
+  if (proxyUsername && proxyPassword) {
+    // undici sets Proxy-Authorization to opts.token verbatim, so it must be a
+    // complete, base64-encoded Basic credential. (opts.auth is deprecated and
+    // must not be combined with token.)
+    const encoded = Buffer.from(`${proxyUsername}:${proxyPassword}`).toString(
+      'base64',
+    );
+    agentOptions.token = `Basic ${encoded}`;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPatterns=httpAgent`
+Expected: PASS (both `httpAgent.test.js` and `httpAgent.enhanced.test.js`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/net/httpAgent.cjs tests/unit/net/httpAgent.enhanced.test.js
+git commit -m "fix(httpAgent): base64-encode proxy credentials via undici token (#122)"
+```
+
+---
+
+### Task 5: parseRegions unique temp BED + consumer-owned cleanup (#121)
+
+**Files:**
+- Modify: `js/io/regionParsing.cjs` (add `node:crypto`; `makeTempBedPath()`; both branches)
+- Modify: `js/commands/download.cjs` (add `node:fs` + `getErrorMessage`; wrap body in `try/finally`)
+- Modify: `varvis-download.cjs:210-214` (delete inline unlink block)
+- Test: `tests/unit/io/regionParsing.test.js`, `tests/unit/commands/download.enhanced.test.js`
+
+**Interfaces:**
+- Consumes: `runDownloadCommand({ finalConfig, regions, tempBedPath }, deps)` already receives `tempBedPath`.
+- Produces: `parseRegions` returns a unique `tempBedPath` per call; `runDownloadCommand` unlinks it in `finally`.
+
+- [ ] **Step 1: Write the failing tests.**
+
+In `tests/unit/io/regionParsing.test.js`, replace the fixed-name `afterEach` (lines 19–21) with per-path cleanup, and add a uniqueness test:
+
+```js
+  const created = [];
+  const track = (result) => {
+    if (result.tempBedPath) created.push(result.tempBedPath);
+    return result;
+  };
+
+  afterEach(() => {
+    for (const p of created.splice(0)) {
+      fs.rmSync(p, { force: true });
+    }
+  });
+```
+
+(Update the existing tests to wrap their `parseRegions(...)` calls with `track(...)`, e.g. `const { regions, tempBedPath } = track(parseRegions({ range: 'chr1:100-200', bed: null }, mockLogger));`.) Then add:
+
+```js
+  test('mints a unique temp BED path per call (not a fixed name)', () => {
+    const a = track(parseRegions({ range: 'chr1:1-10', bed: null }, mockLogger));
+    const b = track(parseRegions({ range: 'chr1:1-10', bed: null }, mockLogger));
+
+    const fixed = path.join(os.tmpdir(), 'regions.bed');
+    expect(a.tempBedPath).not.toBe(fixed);
+    expect(b.tempBedPath).not.toBe(fixed);
+    expect(a.tempBedPath).not.toBe(b.tempBedPath);
+  });
+```
+
+In `tests/unit/commands/download.enhanced.test.js`, add a test asserting temp-BED cleanup on throw. (Check the file's existing mock setup for `getDownloadLinks`/`fetchAnalysisIds`; adapt the mock used to force a throw.) Skeleton:
+
+```js
+const fs = require('node:fs');
+// ...
+test('removes the temp BED file even when the download throws', async () => {
+  const tempBedPath = '/tmp/varvis-regions-test.bed';
+  jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+  const unlink = jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+  // Force the flow to throw after parseRegions (e.g. analysis fetch rejects):
+  fetchAnalysisIds.mockRejectedValueOnce(new Error('boom'));
+
+  await expect(
+    runDownloadCommand(
+      { finalConfig: { ...baseConfig, analysisIds: [] }, regions: ['chr1:1-2'], tempBedPath },
+      deps,
+    ),
+  ).rejects.toThrow('boom');
+
+  expect(unlink).toHaveBeenCalledWith(tempBedPath);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --testPathPatterns="regionParsing|download.enhanced"`
+Expected: FAIL — parseRegions returns fixed name; runDownloadCommand doesn't unlink on throw.
+
+- [ ] **Step 3: Implement.**
+
+In `js/io/regionParsing.cjs`, add `const crypto = require('node:crypto');` to the requires, add the helper after the requires:
+
+```js
+/**
+ * Builds a collision-free temporary BED path in the OS temp dir. The pid keeps
+ * concurrent invocations from overwriting each other; the random suffix guards
+ * against same-process/same-clock collisions.
+ *
+ * @returns {string} - Unique temporary BED path for this invocation.
+ */
+function makeTempBedPath() {
+  return path.join(
+    os.tmpdir(),
+    `varvis-regions-${process.pid}-${crypto.randomBytes(6).toString('hex')}.bed`,
+  );
+}
+```
+
+Replace both `const tempBedPath = path.join(os.tmpdir(), 'regions.bed');` (lines 50 and 70) with `const tempBedPath = makeTempBedPath();`.
+
+In `js/commands/download.cjs`, add to requires:
+
+```js
+const fs = require('node:fs');
+const { getErrorMessage } = require('../errorUtils.cjs');
+```
+
+Wrap the entire existing body of `runDownloadCommand` (everything after the destructure of `finalConfig`) in `try { ... } finally { ... }`:
+
+```js
+  try {
+    // ... existing body unchanged (tool checks through generateReport) ...
+  } finally {
+    if (tempBedPath && fs.existsSync(tempBedPath)) {
+      try {
+        fs.unlinkSync(tempBedPath);
+        logger.info(`Deleted temporary BED file: ${tempBedPath}`);
+      } catch (error) {
+        logger.debug(
+          `Could not remove temp BED ${tempBedPath}: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+  }
+```
+
+In `varvis-download.cjs`, delete the inline cleanup (lines 211–214):
+
+```js
+      if (tempBedPath) {
+        fs.unlinkSync(tempBedPath);
+        activeLogger.info(`Deleted temporary BED file: ${tempBedPath}`);
+      }
+```
+
+(Leave `const { regions, tempBedPath } = parseRegions(...)` and the `runDownloadCommand({ finalConfig, regions, tempBedPath }, deps)` call intact — the command now owns cleanup.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --testPathPatterns="regionParsing|download"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/io/regionParsing.cjs js/commands/download.cjs varvis-download.cjs tests/unit/io/regionParsing.test.js tests/unit/commands/download.enhanced.test.js
+git commit -m "fix(regions): unique temp BED path + consumer-owned finally cleanup (#121)"
+```
+
+---
+
+### Task 6: Full gate + finalize
+
+- [ ] **Step 1: Run the full local gate**
+
+Run: `npm run check`
+Expected: PASS — `lint && prettier --check && type-check && test && architecture:check`.
+
+- [ ] **Step 2: Fix any lint/format/type findings**
+
+If prettier flags formatting: `npm run format`. If eslint flags: address per rule (never weaken jsdoc/security/no-secrets rules). If tsc flags: narrow types (do not `any`-cast). Re-run `npm run check`.
+
+- [ ] **Step 3: Commit any gate fixups (if needed)**
+
+```bash
+git add -A
+git commit -m "chore: satisfy lint/format/type gate for #121-#125 batch"
+```
+
+## Self-Review
+
+- **Spec coverage:** D1→Task1, D2→Task2, D3→Task3, D4→Task4, D5→Task5, verification→Task6. All five defects + the D5 cleanup-on-throw test (Codex Medium) covered.
+- **Placeholders:** Task 5's `download.enhanced.test.js` skeleton depends on that file's existing mock wiring — the implementer must read the file's top mocks (`fetchAnalysisIds`, `getDownloadLinks`, `deps`, `baseConfig`) and adapt names. This is the one place exact code can't be pinned without re-reading the file at execution time; everything else is literal.
+- **Type consistency:** `HttpResponseError.status/retryable`, `makeTempBedPath()`, `runDownloadCommand({ finalConfig, regions, tempBedPath }, deps)` used consistently across tasks.

--- a/docs/superpowers/specs/2026-07-07-scanning-bugs-batch-121-125-design.md
+++ b/docs/superpowers/specs/2026-07-07-scanning-bugs-batch-121-125-design.md
@@ -1,0 +1,352 @@
+# Design: scanning-for-bugs batch fixes (#121–#125)
+
+- **Date:** 2026-07-07
+- **Status:** Draft (pending Codex xhigh review)
+- **Scope:** Five independent, already-verified defects surfaced by the repo
+  `scanning-for-bugs` skill. Each is small, module-local, and testable in
+  isolation. This batch is **out of scope** of the earlier CLI-config/lifecycle
+  spec (`2026-07-06-cli-config-and-lifecycle-fixes-design.md`, D1–D8).
+
+## Goal
+
+Fix all five defects end-to-end with focused unit tests, no behavior
+regressions, and a green local gate (`npm run check`). Each fix changes exactly
+one production module (plus the entry file for D5's cleanup move) and updates the
+tests that currently pin the buggy behavior.
+
+## Non-goals
+
+- No refactor of the streaming/download architecture beyond the minimal
+  backpressure fix.
+- No new external tool dependencies, no new CLI flags, no config surface change.
+- No change to the resume path's temp-BED handling. It is the **structural**
+  reference for D5 (unique-per-item name + `try/finally` cleanup owned by the
+  consumer). Resume's uniqueness comes from `analysisId`+`fileName`
+  (`resume.cjs:184`), which is already collision-free per entry, so it is
+  deliberately *not* randomized — only the primary `parseRegions` path (which
+  has no such discriminator) gets the pid+random name.
+
+---
+
+## D1 — apiClient.fetchWithRetry: fast-fail permanent 4xx + honest backoff (#125)
+
+**File:** `js/apiClient.cjs` (`ApiClient.fetchWithRetry`)
+
+**Problem.** `if (!response.ok) throw` makes every non-2xx a retryable error, so
+a permanent 4xx (400/401/403/404) is retried 3× with sleeps before the real
+error surfaces. The delay `attempt * 1000` is linear (1s, 2s, 3s) but the inline
+comment says "Exponential backoff".
+
+**Root cause.** No status-class discrimination between terminal (4xx) and
+transient (5xx / network / 429) failures; mislabeled comment.
+
+**Fix.**
+
+1. Define a **typed error class** carrying the status and a transient/retryable
+   flag. A plain `Error` with ad-hoc `.status`/`.retryable` fields fails
+   `tsc --noEmit` under this repo's strict `checkJs`; a class with JSDoc-typed
+   fields (and `instanceof` narrowing in `catch`, where the binding is `unknown`)
+   is type-safe:
+
+   ```js
+   /**
+    * Error for a non-2xx HTTP response, tagging the status and whether the
+    * failure is transient (worth retrying).
+    */
+   class HttpResponseError extends Error {
+     /** @param {number} status - HTTP status code. */
+     constructor(status) {
+       super(`Fetch failed with status: ${status}`);
+       this.name = 'HttpResponseError';
+       /** @type {number} */
+       this.status = status;
+       /** @type {boolean} */
+       this.retryable = status >= 500 || status === 429;
+     }
+   }
+   ```
+
+   ```js
+   if (!response.ok) throw new HttpResponseError(response.status);
+   ```
+
+2. In `catch`, retry only when the error is retryable **and** attempts remain.
+   Network errors (thrown by `fetch` itself) are plain `Error` instances, not
+   `HttpResponseError`, so they default to retryable via the narrowing:
+
+   ```js
+   const isRetryable = !(error instanceof HttpResponseError) || error.retryable;
+   if (isRetryable && attempt < retries) {
+     this.logger.warn(`Fetch attempt ${attempt} failed. Retrying...`);
+     await new Promise((res) =>
+       setTimeout(res, 2 ** (attempt - 1) * BASE_DELAY_MS),
+     );
+   } else {
+     this.logger.error(
+       `Fetch failed after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${getErrorMessage(error)}`,
+     );
+     throw error;
+   }
+   ```
+
+   `BASE_DELAY_MS = 1000` module constant. This is **true exponential** backoff
+   (1s, 2s, 4s, …); the comment is corrected to match. `HttpResponseError` is
+   exported for tests/consumers.
+
+**Contract.** Retry only transient failures (network errors, HTTP 5xx, HTTP
+429). Fail fast on all other 4xx. Backoff grows exponentially from a 1s base.
+
+**Considered risk.** A caller that relied on retrying a 4xx to eventually
+succeed would change. There is none: every call here is idempotent GET/HEAD or a
+POST-restore; a 4xx never becomes 2xx on identical retry. Expired-S3-URL 403s are
+handled proactively upstream (`isUrlExpiringSoon` / `getValidDownloadUrl`), not
+by 4xx retry, so fast-failing them is strictly better (less latency/noise).
+
+**Error-message note.** The failure log reports the actual attempt count
+(`attempt`), so a fast-failed 4xx reads "after 1 attempt". For the exhausted
+network cases, `attempt === retries`, so `after ${attempt} attempts` yields
+"after 3 attempts" / "after 5 attempts" — the existing assertions
+(`apiClient.test.js:116,181`) stay green. The `attempt === 1 ? '' : 's'`
+pluralization keeps grammar correct across both paths.
+
+**Tests (`tests/unit/apiClient.test.js`).**
+- Keep: "retry on non-ok response status" (uses 500 → still retryable).
+- Keep: exponential-backoff test (advances 1000 then 2000ms; true-exponential
+  yields identical 1000/2000 for the first two retries → stays green).
+- Add: "fails fast on 404 without retrying" — `fetch` resolves `{ok:false,
+  status:404}`; assert `fetch` called once, no `warn`, error thrown.
+- Add: "retries on 429" — assert it is treated as transient.
+
+---
+
+## D2 — rangedDownloadVCF: argv array instead of `sh -c` (#124)
+
+**File:** `js/rangedUtils.cjs` (`rangedDownloadVCF`, ~lines 140–146)
+
+**Problem.** The tabix half of the pipeline is built as a shell string and run
+via `spawn('sh', ['-c', `tabix -h "${url}" ${range}`], { cwd })`. `range` is
+interpolated **unquoted**; the URL is only double-quoted (still interprets `$`,
+backticks, `\`, `"`). Shell metacharacters in a region break the command or
+execute unintended shell. The BAM path already uses safe argv arrays.
+
+**Fix.** Match the BAM path — spawn `tabix` directly with an argument array, no
+shell:
+
+```js
+logger.info(`Executing in ${indexDir}: tabix -h ${url} ${range}`);
+const tabixProcess = spawn('tabix', ['-h', url, range], { cwd: indexDir });
+```
+
+`range` is always a **single** region string: `handleVcfFile` loops per region
+(`vcfHandler.cjs:120-138`) and the resume path passes one region. So one argv
+slot for `range` is correct; no splitting needed. The log line no longer prints
+a shell-executable string (it is descriptive only).
+
+**Contract.** The ranged VCF download runs `tabix` with the URL and region as
+distinct argv entries in `indexDir`, piped to `bgzip -c` (unchanged), with no
+shell interpretation of any input.
+
+**Tests (`tests/unit/rangedUtils.test.js`).** Update the two assertions that pin
+`spawn('sh', ['-c', ...])` (lines ~284 and ~390) to:
+
+```js
+expect(spawn).toHaveBeenCalledWith('tabix', ['-h', url, range], { cwd: '/path/to' });
+```
+
+No other test references the shell form. (`vcfHandler` and `resume` tests mock
+`rangedDownloadVCF` wholesale and are unaffected.)
+
+---
+
+## D3 — downloadFile: honor writable backpressure (#123)
+
+**File:** `js/fileUtils.cjs` (`downloadFile` streaming loop, ~lines 84–89)
+
+**Problem.** `writer.write(chunk)` return value is ignored and `drain` is never
+awaited, so a slow sink lets Node buffer unbounded data in the writable's queue
+(multi-GB BAMs → RSS toward file size, possible OOM).
+
+**Fix.** Await `drain` when `write()` signals a full buffer:
+
+```js
+const { once } = require('node:events');
+...
+for await (const chunk of response.body) {
+  totalBytes += chunk.length;
+  if (!writer.write(chunk)) {
+    await once(writer, 'drain');
+  }
+  progressBar.tick(chunk.length);
+}
+```
+
+`events.once(writer, 'drain')` resolves on `drain` and **auto-rejects on
+`error`**, so a mid-download writer error still propagates into the existing
+`catch` (which destroys the stream and unlinks the partial file). Progress
+ticking and metrics are unchanged.
+
+**Contract.** Memory stays bounded by the writable high-water mark regardless of
+the network/disk speed ratio; behavior and outputs are otherwise identical.
+
+**Tests (`tests/unit/fileUtils.test.js`).**
+- Existing tests unaffected: they use a real `fs.createWriteStream` with tiny
+  (<16 KB) buffers, so `write()` returns `true` and the drain path is never hit.
+- Add a deterministic backpressure test: `jest.spyOn(fs, 'createWriteStream')`
+  returns a real `stream.Writable` with `highWaterMark: 1` and an async
+  `_write` (callback on `setImmediate`). The mock body yields several chunks and
+  records the pull order; `_write` records the write order. With hwm=1 and the
+  fix, pulls and writes interleave 1:1 (proving `drain` is awaited between
+  chunks); without the fix all pulls precede all writes. Assert the interleaved
+  order and correct `totalBytesDownloaded`.
+
+---
+
+## D4 — createHttpAgent: base64 proxy auth via `token` (#122)
+
+**File:** `js/net/httpAgent.cjs` (`createHttpAgent`)
+
+**Problem.** `agentOptions.auth = `${proxyUsername}:${proxyPassword}`` passes the
+**raw** pair, but undici treats `opts.auth` as **already base64**, emitting
+`Proxy-Authorization: Basic user:pass` (literal), which authenticating proxies
+reject. Verified in `node_modules/undici/lib/dispatcher/proxy-agent.js`: `auth`
+→ `Basic ${opts.auth}` (:138), `token` → set verbatim (:140), and `auth`+`token`
+together throw (:134). `auth` is `@deprecated` in favor of `token`.
+
+**Fix.** Use the non-deprecated `token` option with a correctly base64-encoded
+credential (set only `token`, never both):
+
+```js
+if (proxyUsername && proxyPassword) {
+  const encoded = Buffer.from(`${proxyUsername}:${proxyPassword}`).toString('base64');
+  agentOptions.token = `Basic ${encoded}`;
+}
+```
+
+**Contract.** With a proxy and both credentials set, undici sends a valid
+`Proxy-Authorization: Basic <base64(user:pass)>`. With only one credential half,
+no auth is sent (unchanged). Non-proxy path unchanged.
+
+**Tests (`tests/unit/net/httpAgent.enhanced.test.js`).** Update the both-set
+assertion from `auth: 'user:pass'` to `token: 'Basic dXNlcjpwYXNz'`
+(base64 of `user:pass`). The "omits auth when only one half present" test stays
+valid (neither `auth` nor `token` set). `httpAgent.test.js` does not assert the
+credential shape and is unaffected. Confirm `tsc --noEmit` accepts `token` on
+`import('undici').ProxyAgent.Options`.
+
+---
+
+## D5 — parseRegions: unique temp BED name + cleanup in `finally` (#121)
+
+**Files:** `js/io/regionParsing.cjs` (unique name), `js/commands/download.cjs`
+(cleanup ownership), `varvis-download.cjs` (drop the leaky inline cleanup).
+
+**Problem.**
+1. Both `parseRegions` branches write a **constant** `os.tmpdir()/regions.bed`.
+   Two concurrent invocations on one host overwrite each other's regions →
+   run A's `samtools -L <tempBed>` reads run B's regions → **wrong-region
+   output, silently** (TOCTOU on a shared temp file).
+2. The primary-path cleanup (`varvis-download.cjs:211-214`,
+   `if (tempBedPath) fs.unlinkSync(...)`) sits in the `try` body, not a
+   `finally`; a throw from `runDownloadCommand` leaks the temp file.
+
+**Fix.**
+1. Mint a unique per-invocation path in both `parseRegions` branches via a small
+   JSDoc'd helper (`js/**/*.cjs` requires JSDoc on function declarations):
+
+   ```js
+   const crypto = require('node:crypto');
+
+   /**
+    * Builds a collision-free temporary BED path in the OS temp dir.
+    *
+    * @returns {string} - Unique temp BED path for this invocation.
+    */
+   function makeTempBedPath() {
+     return path.join(
+       os.tmpdir(),
+       `varvis-regions-${process.pid}-${crypto.randomBytes(6).toString('hex')}.bed`,
+     );
+   }
+   ```
+
+   `process.pid` distinguishes concurrent invocations (the stated bug); the
+   random suffix is defense-in-depth against same-process/same-clock collisions.
+   Single-file cleanup semantics are preserved (no temp dir), matching both call
+   sites (primary and resume) which `fs.unlinkSync` the path.
+
+2. Give the **consumer** (`runDownloadCommand`, which already receives
+   `tempBedPath`) ownership of cleanup via `try/finally`, and remove the leaky
+   inline unlink from the entry point. This both fixes the leak-on-throw and
+   makes cleanup unit-testable (the entry `main()` has no harness; the download
+   command does — `tests/unit/commands/download.enhanced.test.js`). This mirrors
+   `resume.cjs:210-214`, where the handler call is wrapped in `try/finally` that
+   unlinks the temp BED.
+
+   In `js/commands/download.cjs` (add `const fs = require('node:fs')` and
+   `getErrorMessage`), wrap the existing body:
+
+   ```js
+   async function runDownloadCommand({ finalConfig, regions, tempBedPath }, deps) {
+     try {
+       // ... existing body ...
+     } finally {
+       if (tempBedPath && fs.existsSync(tempBedPath)) {
+         try {
+           fs.unlinkSync(tempBedPath);
+           logger.info(`Deleted temporary BED file: ${tempBedPath}`);
+         } catch (error) {
+           logger.debug(`Could not remove temp BED ${tempBedPath}: ${getErrorMessage(error)}`);
+         }
+       }
+     }
+   }
+   ```
+
+   In `varvis-download.cjs`, delete the `if (tempBedPath) { fs.unlinkSync(...) }`
+   block (lines 211-214); `runDownloadCommand` now owns the lifecycle. Nothing
+   throws between `parseRegions` and `runDownloadCommand`, so no leak window
+   remains at the entry point.
+
+**Contract.** Each invocation writes its regions to a path no other invocation
+can collide with, and that path is removed on both success and error (including
+when the download throws or the list-URLs early return fires).
+
+**Tests.**
+- `tests/unit/io/regionParsing.test.js`: replace the fixed-name `afterEach`
+  cleanup (`rmSync(os.tmpdir()/regions.bed)`) with cleanup of the actual returned
+  `tempBedPath`; keep content assertions (they read `tempBedPath`, path-agnostic).
+  Add: two `parseRegions` calls return **different** `tempBedPath` values, and
+  neither equals `os.tmpdir()/regions.bed`.
+- `tests/unit/commands/download.enhanced.test.js`: add a test that
+  `runDownloadCommand` unlinks `tempBedPath` when a downstream handler throws
+  (spy `fs.unlinkSync`, force `handleBamFile`/`getDownloadLinks` to reject,
+  assert unlink was called and the error still propagates).
+
+---
+
+## Cross-cutting
+
+- **Independence.** The five fixes touch disjoint modules (apiClient, rangedUtils,
+  fileUtils, httpAgent, regionParsing + entry). They can be implemented and
+  verified in any order; each ships with its own passing tests.
+- **Isolation & boundaries.** No public function signatures change. No new files
+  needed (all target files are well under the 600-line budget; the largest,
+  `rangedUtils.cjs` at 463 lines and `varvis-download.cjs` at 244, stay within
+  budget). No new dependencies (`node:events`, `node:crypto` are built-ins).
+- **JSDoc/types.** New tagged-error fields in D1 are internal to the catch; no
+  exported type change. Verify `npm run type-check` stays green for D4's `token`.
+
+## Verification
+
+Per fix: `npm test -- --testPathPatterns=<module>`. Final gate: `npm run check`
+(`lint && prettier --check && type-check && test && architecture:check`).
+
+## Test plan summary
+
+| Defect | Prod change | Tests updated | Tests added |
+|--------|-------------|---------------|-------------|
+| D1 #125 | `js/apiClient.cjs` | comment/message | 404 fast-fail; 429 retry |
+| D2 #124 | `js/rangedUtils.cjs` | 2× `sh`→`tabix` argv | (covered by updated) |
+| D3 #123 | `js/fileUtils.cjs` | none | deterministic backpressure |
+| D4 #122 | `js/net/httpAgent.cjs` | 1× `auth`→`token` | (covered by updated) |
+| D5 #121 | `js/io/regionParsing.cjs`, `varvis-download.cjs` | fixed-name cleanup | uniqueness |

--- a/js/apiClient.cjs
+++ b/js/apiClient.cjs
@@ -12,6 +12,30 @@ const DEFAULT_HEADERS = {
 };
 
 /**
+ * Base delay (ms) for exponential backoff between fetch retries.
+ * @type {number}
+ */
+const BASE_DELAY_MS = 1000;
+
+/**
+ * Error for a non-2xx HTTP response, tagging the status code and whether the
+ * failure is transient (network/5xx/429) and therefore worth retrying.
+ */
+class HttpResponseError extends Error {
+  /**
+   * @param {number} status - HTTP status code of the failed response.
+   */
+  constructor(status) {
+    super(`Fetch failed with status: ${status}`);
+    this.name = 'HttpResponseError';
+    /** @type {number} */
+    this.status = status;
+    /** @type {boolean} */
+    this.retryable = status >= 500 || status === 429;
+  }
+}
+
+/**
  * API Client class for handling HTTP requests with retry logic and agent management.
  */
 class ApiClient {
@@ -40,16 +64,22 @@ class ApiClient {
           headers: { ...DEFAULT_HEADERS, ...options.headers },
           dispatcher: this.agent,
         });
-        if (!response.ok)
-          throw new Error(`Fetch failed with status: ${response.status}`);
+        if (!response.ok) throw new HttpResponseError(response.status);
         return response;
       } catch (error) {
-        if (attempt < retries) {
+        // Network errors (plain Error) are transient; only HttpResponseError
+        // for a permanent 4xx (retryable === false) short-circuits the retries.
+        const isRetryable =
+          !(error instanceof HttpResponseError) || error.retryable;
+        if (isRetryable && attempt < retries) {
           this.logger.warn(`Fetch attempt ${attempt} failed. Retrying...`);
-          await new Promise((res) => setTimeout(res, attempt * 1000)); // Exponential backoff
+          // True exponential backoff: 1s, 2s, 4s, ...
+          await new Promise((res) =>
+            setTimeout(res, 2 ** (attempt - 1) * BASE_DELAY_MS),
+          );
         } else {
           this.logger.error(
-            `Fetch failed after ${retries} attempts: ${getErrorMessage(error)}`,
+            `Fetch failed after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${getErrorMessage(error)}`,
           );
           throw error;
         }
@@ -90,6 +120,7 @@ async function fetchWithRetry(url, options, retries = 3, logger) {
 
 module.exports = {
   ApiClient,
+  HttpResponseError,
   createApiClient,
   fetchWithRetry,
 };

--- a/js/apiClient.cjs
+++ b/js/apiClient.cjs
@@ -23,6 +23,7 @@ const BASE_DELAY_MS = 1000;
  */
 class HttpResponseError extends Error {
   /**
+   * Creates an HttpResponseError for a failed HTTP response.
    * @param {number} status - HTTP status code of the failed response.
    */
   constructor(status) {

--- a/js/commands/download.cjs
+++ b/js/commands/download.cjs
@@ -1,3 +1,4 @@
+const fs = require('node:fs');
 const {
   fetchAnalysisIds,
   generateReport,
@@ -6,6 +7,7 @@ const {
 const { handleBamFile } = require('../download/bamHandler.cjs');
 const { handleVcfFile } = require('../download/vcfHandler.cjs');
 const { OperationalError } = require('../errors.cjs');
+const { getErrorMessage } = require('../errorUtils.cjs');
 const { handleUrlListing } = require('../io/urlListing.cjs');
 const { checkToolAvailability } = require('../toolChecks.cjs');
 
@@ -39,112 +41,129 @@ async function runDownloadCommand({ finalConfig, regions, tempBedPath }, deps) {
     urlFile,
   } = finalConfig;
 
-  if (finalConfig.range || finalConfig.bed || finalConfig.unmapped) {
-    const samtoolsOK = await checkToolAvailability(
-      'samtools',
-      'samtools --version',
-      '1.17',
-      logger,
-    );
-    if (!samtoolsOK) {
-      throw new OperationalError(
-        'samtools is missing or outdated. Please install/update it and try again.',
+  try {
+    if (finalConfig.range || finalConfig.bed || finalConfig.unmapped) {
+      const samtoolsOK = await checkToolAvailability(
+        'samtools',
+        'samtools --version',
+        '1.17',
+        logger,
       );
-    }
-
-    if (finalConfig.range || finalConfig.bed) {
-      const [tabixOK, bgzipOK] = await Promise.all([
-        checkToolAvailability('tabix', 'tabix --version', '1.7', logger),
-        checkToolAvailability('bgzip', 'bgzip --version', '1.7', logger),
-      ]);
-      if (!tabixOK || !bgzipOK) {
+      if (!samtoolsOK) {
         throw new OperationalError(
-          'One or more required external tools (tabix, bgzip) are missing or outdated. Please install/update them and try again.',
+          'samtools is missing or outdated. Please install/update it and try again.',
         );
       }
-    }
-  }
 
-  logger.info('Processing files for download...');
-  const ids =
-    analysisIds.length > 0
-      ? analysisIds
-      : await fetchAnalysisIds(
-          target,
-          authService.token,
-          agent,
-          sampleIds,
-          limsIds,
-          filters,
-          logger,
-          finalConfig.latest,
-        );
-  logger.info(`Fetched analysis IDs: ${ids}`);
-
-  const optionsForRestoration = {
-    destination: finalConfig.destination,
-    overwrite: finalConfig.overwrite,
-    range: finalConfig.range,
-    bed: finalConfig.bed,
-    unmapped: finalConfig.unmapped,
-    restorationFile,
-    filetypes,
-  };
-
-  /** @type {string[]} */
-  const allUrls = [];
-
-  for (const analysisId of ids) {
-    logger.info(`Processing analysis ID: ${analysisId}`);
-    const fileDict = await getDownloadLinks(
-      analysisId,
-      filetypes,
-      target,
-      authService.token,
-      agent,
-      logger,
-      restoreArchived,
-      rl,
-      restorationFile,
-      optionsForRestoration,
-    );
-    logger.debug(`Fetched download links for analysis ID ${analysisId}`);
-
-    if (listUrls) {
-      for (const file of Object.values(fileDict)) {
-        if (file.downloadLink) {
-          allUrls.push(file.downloadLink);
+      if (finalConfig.range || finalConfig.bed) {
+        const [tabixOK, bgzipOK] = await Promise.all([
+          checkToolAvailability('tabix', 'tabix --version', '1.7', logger),
+          checkToolAvailability('bgzip', 'bgzip --version', '1.7', logger),
+        ]);
+        if (!tabixOK || !bgzipOK) {
+          throw new OperationalError(
+            'One or more required external tools (tabix, bgzip) are missing or outdated. Please install/update them and try again.',
+          );
         }
       }
-      continue;
     }
 
-    const primaryFiles = Object.entries(fileDict).filter(
-      ([fileName]) => fileName.endsWith('.bam') || fileName.endsWith('.vcf.gz'),
-    );
+    logger.info('Processing files for download...');
+    const ids =
+      analysisIds.length > 0
+        ? analysisIds
+        : await fetchAnalysisIds(
+            target,
+            authService.token,
+            agent,
+            sampleIds,
+            limsIds,
+            filters,
+            logger,
+            finalConfig.latest,
+          );
+    logger.info(`Fetched analysis IDs: ${ids}`);
 
-    for (const [fileName] of primaryFiles) {
-      if (fileName.endsWith('.bam')) {
-        await handleBamFile(
-          { fileDict, fileName, finalConfig, regions, target, tempBedPath },
-          deps,
-        );
-      } else if (fileName.endsWith('.vcf.gz')) {
-        await handleVcfFile(
-          { fileDict, fileName, finalConfig, regions, target },
-          deps,
+    const optionsForRestoration = {
+      destination: finalConfig.destination,
+      overwrite: finalConfig.overwrite,
+      range: finalConfig.range,
+      bed: finalConfig.bed,
+      unmapped: finalConfig.unmapped,
+      restorationFile,
+      filetypes,
+    };
+
+    /** @type {string[]} */
+    const allUrls = [];
+
+    for (const analysisId of ids) {
+      logger.info(`Processing analysis ID: ${analysisId}`);
+      const fileDict = await getDownloadLinks(
+        analysisId,
+        filetypes,
+        target,
+        authService.token,
+        agent,
+        logger,
+        restoreArchived,
+        rl,
+        restorationFile,
+        optionsForRestoration,
+      );
+      logger.debug(`Fetched download links for analysis ID ${analysisId}`);
+
+      if (listUrls) {
+        for (const file of Object.values(fileDict)) {
+          if (file.downloadLink) {
+            allUrls.push(file.downloadLink);
+          }
+        }
+        continue;
+      }
+
+      const primaryFiles = Object.entries(fileDict).filter(
+        ([fileName]) =>
+          fileName.endsWith('.bam') || fileName.endsWith('.vcf.gz'),
+      );
+
+      for (const [fileName] of primaryFiles) {
+        if (fileName.endsWith('.bam')) {
+          await handleBamFile(
+            { fileDict, fileName, finalConfig, regions, target, tempBedPath },
+            deps,
+          );
+        } else if (fileName.endsWith('.vcf.gz')) {
+          await handleVcfFile(
+            { fileDict, fileName, finalConfig, regions, target },
+            deps,
+          );
+        }
+      }
+    }
+
+    if (listUrls) {
+      handleUrlListing(allUrls, urlFile, logger);
+      return;
+    }
+
+    logger.info('Download complete.');
+    generateReport(reportfile, logger);
+  } finally {
+    // The temp BED is created before this command runs; clean it up on every
+    // exit path (success, early return, or throw) so a failed download does not
+    // leak it. This command owns the file's lifecycle (mirrors resume.cjs).
+    if (tempBedPath && fs.existsSync(tempBedPath)) {
+      try {
+        fs.unlinkSync(tempBedPath);
+        logger.info(`Deleted temporary BED file: ${tempBedPath}`);
+      } catch (error) {
+        logger.debug(
+          `Could not remove temp BED ${tempBedPath}: ${getErrorMessage(error)}`,
         );
       }
     }
   }
-
-  if (listUrls) {
-    handleUrlListing(allUrls, urlFile, logger);
-    return;
-  }
-
-  logger.info('Download complete.');
-  generateReport(reportfile, logger);
 }
 
 module.exports = { runDownloadCommand };

--- a/js/fileUtils.cjs
+++ b/js/fileUtils.cjs
@@ -1,4 +1,5 @@
 const fs = require('node:fs');
+const { once } = require('node:events');
 const { finished } = require('node:stream/promises');
 const ProgressBar = require('progress');
 const { fetchWithRetry } = require('./apiClient.cjs');
@@ -83,7 +84,14 @@ async function downloadFile(
 
     for await (const chunk of response.body) {
       totalBytes += chunk.length;
-      writer.write(chunk);
+      // Honor writable backpressure: when the internal buffer is full,
+      // write() returns false — wait for 'drain' before pulling the next chunk
+      // so memory stays bounded on large downloads with a slow sink.
+      // events.once() rejects on 'error', so a mid-download writer failure still
+      // propagates into the catch below.
+      if (!writer.write(chunk)) {
+        await once(writer, 'drain');
+      }
       progressBar.tick(chunk.length);
     }
     writer.end();

--- a/js/io/regionParsing.cjs
+++ b/js/io/regionParsing.cjs
@@ -1,9 +1,24 @@
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
 const { OperationalError } = require('../errors.cjs');
 const { getErrorMessage } = require('../errorUtils.cjs');
+
+/**
+ * Builds a collision-free temporary BED path in the OS temp dir. The pid keeps
+ * concurrent invocations from overwriting each other's regions; the random
+ * suffix guards against same-process/same-clock collisions.
+ *
+ * @returns {string} - Unique temporary BED path for this invocation.
+ */
+function makeTempBedPath() {
+  return path.join(
+    os.tmpdir(),
+    `varvis-regions-${process.pid}-${crypto.randomBytes(6).toString('hex')}.bed`,
+  );
+}
 
 /**
  * @typedef {object} RegionOptions
@@ -47,7 +62,7 @@ function parseRegions({ range, bed }, logger) {
     const regions = range.split(' ');
     logger.info(`Using regions from command line: ${regions}`);
 
-    const tempBedPath = path.join(os.tmpdir(), 'regions.bed');
+    const tempBedPath = makeTempBedPath();
     const bedContent = regions.map(regionToBedLine).join('\n');
 
     fs.writeFileSync(tempBedPath, bedContent);
@@ -67,7 +82,7 @@ function parseRegions({ range, bed }, logger) {
         });
       logger.info(`Using regions from BED file: ${regions}`);
 
-      const tempBedPath = path.join(os.tmpdir(), 'regions.bed');
+      const tempBedPath = makeTempBedPath();
       fs.writeFileSync(tempBedPath, bedFileContent);
       logger.info(`Generated temporary BED file: ${tempBedPath}`);
       return { regions, tempBedPath };

--- a/js/net/httpAgent.cjs
+++ b/js/net/httpAgent.cjs
@@ -25,7 +25,13 @@ function createHttpAgent({ proxy, proxyUsername, proxyPassword }) {
   /** @type {import('undici').ProxyAgent.Options} */
   const agentOptions = { uri: proxy };
   if (proxyUsername && proxyPassword) {
-    agentOptions.auth = `${proxyUsername}:${proxyPassword}`;
+    // undici writes opts.token verbatim into the Proxy-Authorization header, so
+    // it must be a complete, base64-encoded Basic credential. (opts.auth is
+    // deprecated and expects an already-encoded value; token is the modern API.)
+    const encoded = Buffer.from(`${proxyUsername}:${proxyPassword}`).toString(
+      'base64',
+    );
+    agentOptions.token = `Basic ${encoded}`;
   }
 
   return new ProxyAgent(agentOptions).compose(cookie({ jar }));

--- a/js/rangedUtils.cjs
+++ b/js/rangedUtils.cjs
@@ -137,11 +137,11 @@ async function rangedDownloadVCF(
     // Get the directory where the index file is located
     const indexDir = path.dirname(indexFile);
 
-    // Command 1: tabix to extract the region with header
-    // CRITICAL: The URL must be quoted to handle special characters in query parameters
-    const tabixCmd = `tabix -h "${url}" ${range}`;
-    logger.info(`Executing in ${indexDir}: ${tabixCmd}`);
-    const tabixProcess = spawn('sh', ['-c', tabixCmd], {
+    // Command 1: tabix to extract the region with header.
+    // Spawn tabix directly with an argv array (no shell) so the URL and range
+    // are inert to shell metacharacters — matching the safe BAM path.
+    logger.info(`Executing in ${indexDir}: tabix -h ${url} ${range}`);
+    const tabixProcess = spawn('tabix', ['-h', url, range], {
       cwd: indexDir, // Execute in the directory where the index file is located
     });
 

--- a/tests/unit/apiClient.test.js
+++ b/tests/unit/apiClient.test.js
@@ -191,6 +191,42 @@ describe('apiClient', () => {
 
         expect(undici.fetch).not.toHaveBeenCalled();
       });
+
+      test('fails fast on 404 without retrying', async () => {
+        undici.fetch.mockResolvedValue({ ok: false, status: 404 });
+
+        const client = new ApiClient(mockAgent, mockLogger);
+
+        await expect(
+          client.fetchWithRetry('https://api.example.com', {}, 3),
+        ).rejects.toThrow('Fetch failed with status: 404');
+
+        expect(undici.fetch).toHaveBeenCalledTimes(1);
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'Fetch failed after 1 attempt: Fetch failed with status: 404',
+        );
+      });
+
+      test('retries on 429 (rate limited) then succeeds', async () => {
+        jest.useFakeTimers();
+        const successResponse = { ok: true, status: 200 };
+        undici.fetch
+          .mockResolvedValueOnce({ ok: false, status: 429 })
+          .mockResolvedValueOnce(successResponse);
+
+        const client = new ApiClient(mockAgent, mockLogger);
+        const promise = client.fetchWithRetry('https://api.example.com', {}, 3);
+        await jest.advanceTimersByTimeAsync(1000);
+        const response = await promise;
+
+        expect(response).toBe(successResponse);
+        expect(undici.fetch).toHaveBeenCalledTimes(2);
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Fetch attempt 1 failed. Retrying...',
+        );
+        jest.useRealTimers();
+      });
     });
   });
 

--- a/tests/unit/commands/download.enhanced.test.js
+++ b/tests/unit/commands/download.enhanced.test.js
@@ -25,6 +25,7 @@ jest.mock('../../../js/io/urlListing.cjs', () => ({
   handleUrlListing: jest.fn(),
 }));
 
+const fs = require('node:fs');
 const { runDownloadCommand } = require('../../../js/commands/download.cjs');
 const {
   fetchAnalysisIds,
@@ -223,5 +224,31 @@ describe('commands/download dispatch wiring', () => {
       mockLogger,
       true,
     );
+  });
+});
+
+describe('commands/download temp BED cleanup', () => {
+  test('removes the temp BED file even when the download throws', async () => {
+    checkToolAvailability.mockResolvedValue(true);
+    getDownloadLinks.mockRejectedValueOnce(new Error('boom'));
+    const existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const unlinkSpy = jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+    const tempBedPath = '/tmp/varvis-regions-test.bed';
+
+    await expect(
+      runDownloadCommand(
+        {
+          finalConfig: makeConfig({ range: 'chr1:1-2' }),
+          regions: ['chr1:1-2'],
+          tempBedPath,
+        },
+        deps,
+      ),
+    ).rejects.toThrow('boom');
+
+    expect(unlinkSpy).toHaveBeenCalledWith(tempBedPath);
+
+    existsSpy.mockRestore();
+    unlinkSpy.mockRestore();
   });
 });

--- a/tests/unit/fileUtils.test.js
+++ b/tests/unit/fileUtils.test.js
@@ -6,6 +6,7 @@ const {
 const { TestDirectory } = require('../helpers/testUtils');
 const fs = require('node:fs');
 const path = require('node:path');
+const { Writable } = require('node:stream');
 
 jest.mock('../../js/apiClient.cjs');
 jest.mock('progress');
@@ -353,6 +354,58 @@ describe('fileUtils', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'Starting download for: https://example.com/file.txt',
       );
+    });
+
+    test('awaits drain when the writable applies backpressure', async () => {
+      const dir = await testDir.create(`download-backpressure-${Date.now()}`);
+      const outputPath = path.join(dir, 'file.bin');
+
+      const order = [];
+      // highWaterMark:1 forces write() to return false, so the fix must await
+      // 'drain' between chunks instead of buffering them all up front.
+      const slowWriter = new Writable({
+        highWaterMark: 1,
+        write(chunk, _enc, cb) {
+          order.push(`write:${chunk.toString()}`);
+          setTimeout(cb, 0);
+        },
+      });
+      jest.spyOn(fs, 'createWriteStream').mockReturnValue(slowWriter);
+
+      const chunks = ['a', 'b', 'c'];
+      const mockBody = {
+        async *[Symbol.asyncIterator]() {
+          for (const c of chunks) {
+            order.push(`pull:${c}`);
+            yield Buffer.from(c);
+          }
+        },
+      };
+      fetchWithRetry.mockResolvedValue({
+        body: mockBody,
+        headers: { get: () => '3' },
+      });
+
+      await downloadFile(
+        'https://example.com/file.bin',
+        outputPath,
+        true,
+        mockAgent,
+        mockRl,
+        mockLogger,
+        mockMetrics,
+      );
+
+      // Backpressure honored => pulls and writes strictly interleave 1:1.
+      expect(order).toEqual([
+        'pull:a',
+        'write:a',
+        'pull:b',
+        'write:b',
+        'pull:c',
+        'write:c',
+      ]);
+      expect(mockMetrics.totalBytesDownloaded).toBe(3);
     });
   });
 });

--- a/tests/unit/io/regionParsing.test.js
+++ b/tests/unit/io/regionParsing.test.js
@@ -11,13 +11,24 @@ describe('io/regionParsing.parseRegions', () => {
     info: jest.fn(),
   };
 
+  const created = [];
+
+  // Records a parseRegions result's temp path so afterEach can clean the
+  // now-unique per-invocation file (there is no longer a fixed name to rm).
+  const track = (result) => {
+    if (result.tempBedPath) created.push(result.tempBedPath);
+    return result;
+  };
+
   beforeEach(() => {
     mockLogger.error.mockClear();
     mockLogger.info.mockClear();
   });
 
   afterEach(() => {
-    fs.rmSync(path.join(os.tmpdir(), 'regions.bed'), { force: true });
+    for (const p of created.splice(0)) {
+      fs.rmSync(p, { force: true });
+    }
   });
 
   test('returns empty regions when neither range nor bed is provided', () => {
@@ -31,9 +42,8 @@ describe('io/regionParsing.parseRegions', () => {
   });
 
   test('parses chr:start-end range and writes a temp BED file', () => {
-    const { regions, tempBedPath } = parseRegions(
-      { range: 'chr1:100-200', bed: null },
-      mockLogger,
+    const { regions, tempBedPath } = track(
+      parseRegions({ range: 'chr1:100-200', bed: null }, mockLogger),
     );
 
     expect(regions).toEqual(['chr1:100-200']);
@@ -41,9 +51,8 @@ describe('io/regionParsing.parseRegions', () => {
   });
 
   test('parses chromosome-only range to a full-chromosome BED interval', () => {
-    const { regions, tempBedPath } = parseRegions(
-      { range: 'chr1', bed: null },
-      mockLogger,
+    const { regions, tempBedPath } = track(
+      parseRegions({ range: 'chr1', bed: null }, mockLogger),
     );
 
     expect(regions).toEqual(['chr1']);
@@ -51,9 +60,8 @@ describe('io/regionParsing.parseRegions', () => {
   });
 
   test('parses space-separated ranges', () => {
-    const { regions, tempBedPath } = parseRegions(
-      { range: 'chr1:1-10 chr2:5-15', bed: null },
-      mockLogger,
+    const { regions, tempBedPath } = track(
+      parseRegions({ range: 'chr1:1-10 chr2:5-15', bed: null }, mockLogger),
     );
 
     expect(regions).toEqual(['chr1:1-10', 'chr2:5-15']);
@@ -68,9 +76,8 @@ describe('io/regionParsing.parseRegions', () => {
     const bedContent = '# comment\nchr1\t10\t20\nchr2\t30\t40\n';
     fs.writeFileSync(bedPath, bedContent);
 
-    const { regions, tempBedPath } = parseRegions(
-      { range: null, bed: bedPath },
-      mockLogger,
+    const { regions, tempBedPath } = track(
+      parseRegions({ range: null, bed: bedPath }, mockLogger),
     );
 
     expect(regions).toEqual(['chr1:10-20', 'chr2:30-40']);
@@ -83,5 +90,19 @@ describe('io/regionParsing.parseRegions', () => {
     expect(() =>
       parseRegions({ range: null, bed: '/missing/input.bed' }, mockLogger),
     ).toThrow(OperationalError);
+  });
+
+  test('mints a unique temp BED path per call (not a fixed name)', () => {
+    const a = track(
+      parseRegions({ range: 'chr1:1-10', bed: null }, mockLogger),
+    );
+    const b = track(
+      parseRegions({ range: 'chr1:1-10', bed: null }, mockLogger),
+    );
+
+    const fixed = path.join(os.tmpdir(), 'regions.bed');
+    expect(a.tempBedPath).not.toBe(fixed);
+    expect(b.tempBedPath).not.toBe(fixed);
+    expect(a.tempBedPath).not.toBe(b.tempBedPath);
   });
 });

--- a/tests/unit/net/httpAgent.enhanced.test.js
+++ b/tests/unit/net/httpAgent.enhanced.test.js
@@ -38,7 +38,7 @@ describe('net/httpAgent.createHttpAgent construction', () => {
 
     expect(ProxyAgent).toHaveBeenCalledWith({
       uri: 'http://example.test:8080',
-      auth: 'user:pass',
+      token: 'Basic dXNlcjpwYXNz', // base64('user:pass')
     });
   });
 

--- a/tests/unit/rangedUtils.test.js
+++ b/tests/unit/rangedUtils.test.js
@@ -281,13 +281,9 @@ describe('rangedUtils', () => {
         true,
       ); // overwrite = true
 
-      expect(spawn).toHaveBeenCalledWith(
-        'sh',
-        ['-c', `tabix -h "${url}" ${range}`],
-        {
-          cwd: expect.any(String),
-        },
-      );
+      expect(spawn).toHaveBeenCalledWith('tabix', ['-h', url, range], {
+        cwd: expect.any(String),
+      });
       expect(spawn).toHaveBeenCalledWith('bgzip', ['-c']);
     });
 
@@ -386,10 +382,10 @@ describe('rangedUtils', () => {
         false,
       );
 
-      // Verify tabix is called with -h flag via shell command
+      // Verify tabix runs directly (no shell) with -h flag and argv array
       expect(spawn).toHaveBeenCalledWith(
-        'sh',
-        ['-c', 'tabix -h "https://example.com/test.vcf.gz" chr1:1000-2000'],
+        'tabix',
+        ['-h', 'https://example.com/test.vcf.gz', 'chr1:1000-2000'],
         { cwd: '/path/to' },
       );
 

--- a/varvis-download.cjs
+++ b/varvis-download.cjs
@@ -206,12 +206,9 @@ async function main() {
         { bed: finalConfig.bed, range: finalConfig.range },
         activeLogger,
       );
+      // runDownloadCommand owns the temp BED lifecycle and removes it in its
+      // own finally (on success, early return, or throw) — no cleanup here.
       await runDownloadCommand({ finalConfig, regions, tempBedPath }, deps);
-
-      if (tempBedPath) {
-        fs.unlinkSync(tempBedPath);
-        activeLogger.info(`Deleted temporary BED file: ${tempBedPath}`);
-      }
     } finally {
       rl.close();
     }


### PR DESCRIPTION
Fixes five independent defects surfaced by the repo `scanning-for-bugs` skill and filed as #121–#125. Each was verified against HEAD, specced, reviewed by Codex (xhigh), and implemented with focused TDD.

## Fixes

| Issue | Module | Change |
|-------|--------|--------|
| #125 | `js/apiClient.cjs` | `fetchWithRetry` now **fast-fails permanent 4xx** (retries only network errors, 5xx, 429) and uses **true exponential backoff** (`2**(n-1)*1000`) with a matching comment. Adds a typed `HttpResponseError` so status-class discrimination is type-safe under strict `checkJs`. |
| #124 | `js/rangedUtils.cjs` | `rangedDownloadVCF` runs tabix via an **argv array** (`spawn('tabix', ['-h', url, range])`) instead of `sh -c` with an interpolated URL/unquoted range — matching the safe BAM path; removes the shell-injection surface and the `sh` dependency. |
| #123 | `js/fileUtils.cjs` | `downloadFile` **honors writable backpressure** (awaits `drain` when `write()` returns `false`), keeping memory bounded on multi-GB full downloads with a slow sink. |
| #122 | `js/net/httpAgent.cjs` | Authenticated proxy: **base64-encode** credentials and use undici's non-deprecated `token` option, so the `Proxy-Authorization` header is valid (was sending a literal `Basic user:pass`). |
| #121 | `js/io/regionParsing.cjs`, `js/commands/download.cjs`, `varvis-download.cjs` | `parseRegions` mints a **unique per-invocation** temp BED name (`varvis-regions-<pid>-<rand>.bed`) instead of a fixed `regions.bed` (fixes a TOCTOU race that silently produced wrong-region output under concurrency). Cleanup moves into `runDownloadCommand`'s `finally`, so the temp file is removed on success, early return, **or throw**. |

## Verification

- `npm run check` green: lint (0 errors), `prettier --check`, `tsc --noEmit` strict, **453 tests**, architecture budget (0 blocking).
- Each fix ships with focused unit tests (TDD: failing test → fix → green), including a deterministic backpressure test and a temp-BED-cleanup-on-throw test (added per Codex review).

## Design docs

- Spec: `docs/superpowers/specs/2026-07-07-scanning-bugs-batch-121-125-design.md`
- Plan: `docs/superpowers/plans/2026-07-07-scanning-bugs-batch-121-125.md`

Closes #121
Closes #122
Closes #123
Closes #124
Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRCFoXRU6wYdMrS3wYGiDE
